### PR TITLE
fix: PoolingFTPManager close bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+.idea
+*.iml

--- a/src/main/java/com/honey/ftpcp/PoolingFTPManager.java
+++ b/src/main/java/com/honey/ftpcp/PoolingFTPManager.java
@@ -42,13 +42,9 @@ public class PoolingFTPManager implements FTPManager {
 		}
 	}
 	public synchronized void close() throws Exception {
-		if(_pool == null && _pool.isClosed()) {
-			return ;
-		}
-		if(_pool != null) {
-			_pool.close();
-		}
-		
+        if (_pool != null && (!_pool.isClosed())) {
+            _pool.close();
+        }
 	}
 
     public FTPConnection getFTPConnection() throws FTPException {
@@ -70,6 +66,5 @@ public class PoolingFTPManager implements FTPManager {
 		this._pool = pool;
 	}
 
-    
 
 }


### PR DESCRIPTION
```_pool == null && _pool.isClosed()``` will throw NullPointException